### PR TITLE
Update paragraph in section 3

### DIFF
--- a/paper/3-static.tex
+++ b/paper/3-static.tex
@@ -23,11 +23,13 @@ assistant~\citep{bertot2013coq}.
 % TODO: Can we get any performance improvement figures on how much more
 % parallelism can be gained through static analysis?
 
-One unusual feature of \Dune is the ability to statically over-approximate all
-build dependencies of a package instead of requiring the programmer to manually
-list them in a \emph{package manifest file}. Package manifest files are consumed
-by \emph{package managers}, such as OPAM~\citep{opam} for the purpose of
-downloading and installing all required dependencies.
+One unusual feature of \Dune is the ability to statically
+over-approximate all build dependencies of a package. This is used at
+Jane Street to automatically produce \emph{package manifest files} for
+more than 100 packages instead of maintaining them by hand. Package
+manifest files are consumed by \emph{package managers}, such as
+OPAM~\citep{opam} for the purpose of downloading and installing all
+required dependencies.
 
 % The original aim of this feature was to automatically generate package manifest
 % files, so that they do not need to be maintained. An alternative approach would


### PR DESCRIPTION
Currently users of Dune still have to write package manifest. Dune has a command to list the package dependencies, however it doesn't produce full package manifest (yet). We have a tool inside Jane Street that reads the output of dune and produce them, however this tool is not currently open source.