### PR TITLE
Prevent building on older GHC versions

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -35,6 +35,7 @@ library
                         mtl          >= 2.2.1   && < 2.3,
                         transformers >= 0.5.2.0 && < 0.6
     default-language:   Haskell2010
+    other-extensions:   DerivingVia
     GHC-options:        -Wall
                         -fno-warn-name-shadowing
                         -Wcompat


### PR DESCRIPTION
by adding DerivingVia to other-extensions