### PR TITLE
Address B's comment on the Processor example [l:921].

### DIFF
--- a/examples/Processor.hs
+++ b/examples/Processor.hs
@@ -7,7 +7,7 @@ import Data.Functor
 import Data.Int (Int16)
 import Data.Word (Word8)
 import Data.Map.Strict (Map)
-import Prelude hiding (read)
+import Prelude hiding (read, log)
 
 import qualified Control.Monad.State as S
 import qualified Data.Map.Strict     as Map
@@ -32,13 +32,13 @@ fromBool False = 0
 type Value = Int16
 
 -- | The processor has four registers.
-data Reg = R1 | R2 | R3 | R4 deriving (Show, Eq, Ord)
+data Reg = R0 | R1 | R2 | R3 deriving (Show, Eq, Ord)
 
 r0, r1, r2, r3 :: Key
-r0 = Reg R1
-r1 = Reg R2
-r2 = Reg R3
-r3 = Reg R4
+r0 = Reg R0
+r1 = Reg R1
+r2 = Reg R2
+r3 = Reg R3
 
 -- | The register bank maps registers to values.
 type RegisterBank = Map Reg Value
@@ -64,10 +64,19 @@ type InstructionAddress = Value
 data State = State { registers :: RegisterBank
                    , memory    :: Memory
                    , pc        :: InstructionAddress
-                   , flags     :: Flags }
+                   , flags     :: Flags
+                   , logs      :: [String] }
+
+
 
 -- | Various elements of the processor state.
-data Key = Reg Reg | Cell Address | Flag Flag | PC deriving (Eq, Show)
+data Key = Reg Reg | Cell Address | Flag Flag | PC deriving Eq
+
+instance Show Key where
+    show (Reg r)  = show r
+    show (Cell a) = show a
+    show (Flag f) = show f
+    show PC       = "PC"
 
 -- | The base functor for mutable processor state.
 data RW a = R Key                 (Value -> a)
@@ -77,29 +86,36 @@ data RW a = R Key                 (Value -> a)
 -- | A program is a free selective on top of the 'RW' base functor.
 type Program a = Select RW a
 
-instance Show a => Show (RW a) where
+instance Show (RW a) where
     show (R k          _) = "Read "  ++ show k
     show (W k (Pure v) _) = "Write " ++ show k ++ " " ++ show v
     show (W k _        _) = "Write " ++ show k
 
+log :: MonadState State m => String -> m ()
+log item = S.modify $ \s ->
+    s {logs = item : logs s }
+
 -- | Interpret the base functor in a 'MonadState'.
 toState :: MonadState State m => RW a -> m a
-toState (R k t) = t <$> case k of
-    Reg  r    -> (Map.! r   ) <$> S.gets registers
-    Cell addr -> (Map.! addr) <$> S.gets memory
-    Flag f    -> (Map.! f   ) <$> S.gets flags
-    PC        -> pc <$> S.get
-toState (W k p t) = case k of
-    Reg r     -> do v <- runSelect toState p
-                    let regs' s = Map.insert r v (registers s)
-                    S.state (\s -> (t v, s {registers = regs' s}))
-    Cell addr -> do v <- runSelect toState p
-                    let mem' s = Map.insert addr v (memory s)
-                    S.state (\s -> (t v, s {memory = mem' s}))
-    Flag f    -> do v <- runSelect toState p
-                    let flags' s = Map.insert f v (flags s)
-                    S.state (\s -> (t v, s {flags = flags' s}))
-    PC          -> error "toState: Can't write the Program Counter (PC)"
+toState op = log (show op) *> case op of
+    (R k t) ->
+        t <$> case k of
+            Reg  r    -> (Map.! r   ) <$> S.gets registers
+            Cell addr -> (Map.! addr) <$> S.gets memory
+            Flag f    -> (Map.! f   ) <$> S.gets flags
+            PC        -> pc <$> S.get
+    (W k p t) ->
+        case k of
+            Reg r     -> do v <- runSelect toState p
+                            let regs' s = Map.insert r v (registers s)
+                            S.state (\s -> (t v, s {registers = regs' s}))
+            Cell addr -> do v <- runSelect toState p
+                            let mem' s = Map.insert addr v (memory s)
+                            S.state (\s -> (t v, s {memory = mem' s}))
+            Flag f    -> do v <- runSelect toState p
+                            let flags' s = Map.insert f v (flags s)
+                            S.state (\s -> (t v, s {flags = flags' s}))
+            PC          -> error "toState: Can't write the Program Counter (PC)"
 
 -- | Interpret a program as a state trasformer.
 runProgramState :: Program a -> State -> (a, State)
@@ -120,7 +136,7 @@ read k = liftSelect (R k id)
 
 -- | A convenient alias for writing into an element of the processor state.
 write :: Key -> Program Value -> Program Value
-write k fv = fv *> liftSelect (W k fv id)
+write k fv = liftSelect (W k fv id) -- fv *> liftSelect (W k fv id)
 
 -- --------------------------------------------------------------------------------
 -- -------- Instructions ----------------------------------------------------------
@@ -239,3 +255,46 @@ willOverflow arg1 arg2 =
         o4 = (<) <$> arg1 <*> ((-) <$> pure minBound <*> arg2)
     in  (||) <$> ((&&) <$> o1 <*> o2)
              <*> ((&&) <$> o3 <*> o4)
+
+-----------------------------------
+-- Example simulations ------------
+-----------------------------------
+
+renderState :: State -> String
+renderState state =
+  "Registers: " <> show (registers state) <> "\n" <>
+  "Flags: " <> show (Map.toList $ flags state) <> "\n" <>
+  "Log: " <>  show (logs state)
+
+instance Show State where
+    show = renderState
+
+emptyRegisters :: RegisterBank
+emptyRegisters = Map.fromList [(R0, 0), (R1, 0), (R2, 0), (R3, 0)]
+
+emptyFlags :: Flags
+emptyFlags = Map.fromList $ zip [Zero, Overflow] [0, 0..]
+
+initialiseMemory :: [(Address, Value)] -> Memory
+initialiseMemory m =
+    let blankMemory = Map.fromList $ zip [0..maxBound] [0, 0..]
+    in foldr (\(addr, value) acc -> Map.adjust (const value) addr acc) blankMemory m
+
+boot :: Memory -> State
+boot mem = State { registers = emptyRegisters
+                 , pc = 0
+                 , flags = emptyFlags
+                 , memory = mem
+                 , logs   = []
+                 }
+
+twoAdds :: Program Value
+twoAdds = add r0 (Cell 0) r0
+          *>
+          add r0 (Cell 0) r0
+
+addExample :: IO ()
+addExample = do
+    let initState = boot (initialiseMemory [(0, 2)])
+    -- print . snd $ runProgramState (add r0 (Cell 0) r0) initState
+    print . snd $ runProgramState (twoAdds) initState

--- a/paper/response.md
+++ b/paper/response.md
@@ -12,8 +12,6 @@ No. We say this in line 192: "Any Applicative instance can thus be given a Selec
 
 > **A:** this is odd because the authors argue that Applicative < Selective < Monad. Thus I would have expected some things to be Applicative, but not Selective.
 
-asdasdasdasd
-
 `Selective` requires one extra method `select` to be implemented compared to the `Applicative` type class, hence the subclass relation. Note also that while `select = selectA` is a perfectly valid implementation of `select`, **it is not the only one**, as demonstrated by `Selective` instances `Over` and `Under`: indeed, `Over` uses `select = selectA`, but `Under` does not.
 
 > **B:** [l:921] In the implementation of write you evaluate the value to get the associated effects. It's clear that this is needed for the static analysis, but I worry that it will lead to quadratic or exponential blowup in the simulation. Is there an argument to be made that this is not the case? (**Please address this in rebuttal**)

--- a/paper/response.md
+++ b/paper/response.md
@@ -12,10 +12,13 @@ No. We say this in line 192: "Any Applicative instance can thus be given a Selec
 
 > **A:** this is odd because the authors argue that Applicative < Selective < Monad. Thus I would have expected some things to be Applicative, but not Selective.
 
+asdasdasdasd
+
 `Selective` requires one extra method `select` to be implemented compared to the `Applicative` type class, hence the subclass relation. Note also that while `select = selectA` is a perfectly valid implementation of `select`, **it is not the only one**, as demonstrated by `Selective` instances `Over` and `Under`: indeed, `Over` uses `select = selectA`, but `Under` does not.
 
 > **B:** [l:921] In the implementation of write you evaluate the value to get the associated effects. It's clear that this is needed for the static analysis, but I worry that it will lead to quadratic or exponential blowup in the simulation. Is there an argument to be made that this is not the case? (**Please address this in rebuttal**)
 
+The implementation of `write` presented in the paper indeed causes exponential blowup in the simulation. This implementation is erroneous. The right way to go is to implement `write` simply as `write k fv = liftSelect (Write k fv id)` thus completely shifting the writing semantics into the natural transformations (e.g. `toState`). This will allow to subsume both correct simulation and static analysis, both implemented by their own natural transformations.
 **TODO: Andrey & Georgy**
 
 > **C:** At least, I would like to see a concrete instance that is Selective but (at least believed) not (to be) ArrowChoice.


### PR DESCRIPTION
Hi Andrey,

I've modified the Processor example so it would not suffer from the exponential blowup in the simulation. 

I've also enriched the processor state with the log of the reads and writes performed during the simulation. I've chosen to do that instead of implementing a separate tracing natural transformation (e.g. `toWriter`) in order to test the supposedly problematic `toState` one. 

Finally, I have added the necessary boilerplate to run simulations.

I have drafted a short reply to reviewer B's comment.