### PR TITLE
Use deriving-compat to support GHC >=8.2 && <8.6

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -36,8 +36,12 @@ library
                         containers   >= 0.5.7.1 && < 7,
                         transformers >= 0.5.2.0 && < 0.6
     default-language:   Haskell2010
+    if impl(ghc>=8.6.1)
+      other-extensions: DerivingVia
+    else
+      other-extensions: TemplateHaskell
+      build-depends:    ghc >= 8.2, deriving-compat >= 0.4.1
     other-extensions:   DeriveFunctor,
-                        DerivingVia,
                         FlexibleInstances,
                         GADTs,
                         GeneralizedNewtypeDeriving,
@@ -79,3 +83,8 @@ test-suite test
                         -Wredundant-constraints
                         -fno-warn-orphans
                         -fno-warn-missing-signatures
+    if impl(ghc>=8.6.1)
+      other-extensions: DerivingVia
+    else
+      other-extensions: TemplateHaskell
+      build-depends:    deriving-compat


### PR DESCRIPTION
This is a cool abstraction but I can't use it on my client projects because they're not on GHC 8.6 yet and this uses the `DerivingVia` extension. With this commit, it uses the `deriving-compat` package to achieve the same instances. After a few more GHC releases you could either leave them in or delete them with an upper bound on the GHC version, for example.

This also implies a lower bound on `ghc` at 8.2.