### PR TITLE
Icfp artefact

### DIFF
--- a/paper/artefact/Dockerfile
+++ b/paper/artefact/Dockerfile
@@ -32,7 +32,7 @@ RUN unzip selective-coq.zip && rm selective-coq.zip && mv selective-theory-coq-0
 # Pull the Haskell sources from GitHub
 RUN wget -O selective.zip https://github.com/snowleopard/selective/archive/v0.2.zip
 RUN unzip selective.zip && rm selective.zip
-RUN cd selective-0.2 && stack build
+RUN cd selective-0.2 && stack build && stack test
 RUN mv selective-0.2 selective-haskell
 
 RUN exit

--- a/paper/artefact/Dockerfile
+++ b/paper/artefact/Dockerfile
@@ -1,0 +1,38 @@
+# Docker image prepared for ICFP'19 Artifact Evaluation.
+#
+# To build the image, run the following command in the directory containing
+# this Dockerfile: `docker build -t geo2a/selective-icfp19 .`
+#
+# To run a container interactively:
+# `docker run -it geo2a/selective-icfp19`
+#
+# We have chosen to use the Coq base image as a base because it includes all
+# software required for building the Coq and OCaml parts of the artefact.
+# We will augment the image with the software require for the Haskell part.
+FROM coqorg/coq:8.9
+
+MAINTAINER Georgy Lukyanov
+
+RUN sudo apt-get update
+RUN sudo apt-get install -y wget m4
+RUN curl -sSL https://get.haskellstack.org/ | sh
+
+# Pull the OCaml sources from GitHub
+RUN wget -O selective-ocaml.zip https://github.com/snowleopard/selective-ocaml/archive/0.1.0.zip && \
+    unzip selective-ocaml.zip && rm selective-ocaml.zip && \
+    cd selective-ocaml-0.1.0 && \
+    opam install -y dune base stdio expect_test_helpers_kernel
+RUN cd selective-ocaml-0.1.0 && eval $(opam env) && make test
+RUN mv selective-ocaml-0.1.0 selective-ocaml
+
+# Pull the Coq sources from GitHub
+RUN wget -O selective-coq.zip https://github.com/tuura/selective-theory-coq/archive/v0.1.zip
+RUN unzip selective-coq.zip && rm selective-coq.zip && mv selective-theory-coq-0.1 selective-coq
+
+# Pull the Haskell sources from GitHub
+RUN wget -O selective.zip https://github.com/snowleopard/selective/archive/v0.2.zip
+RUN unzip selective.zip && rm selective.zip
+RUN cd selective-0.2 && stack build
+RUN mv selective-0.2 selective-haskell
+
+RUN exit

--- a/paper/artefact/README.md
+++ b/paper/artefact/README.md
@@ -1,0 +1,85 @@
+# ICFP 2019 Artifact Evaluation submission
+
+This image contains a snapshot of the software packages related to the paper "Selective Applicative Functors" and all their dependencies.
+
+
+## Running the image
+
+To run it interactively use the command: `docker run -it geo2a/selective-icfp19`.
+You will find yourself in the directory `/home/coq`.
+
+## Check Coq proofs
+
+To access th Coq development, execute the following command:
+
+```
+cd ~/selective-coq
+```
+
+To verify the Coq proofs of several Selective instances being lawful, execute:
+
+```
+make
+```
+
+TODO: what instance have been proven.
+
+## Run Haskell tests
+
+```
+cd ~/selective-haskell
+```
+
+## Run OCaml tests
+
+```
+cd ~/selective-ocaml
+```
+
+# Further activities
+
+
+# Dockerfile
+
+Created using the following Dockerfile:
+
+```
+# Docker image prepared for ICFP'19 Artifact Evaluation.
+#
+# To build the image, run the following command in the directory containing
+# this Dockerfile: `docker build -t geo2a/selective-icfp19 .`
+#
+# To run a container interactively:
+# `docker run -it geo2a/selective-icfp19`
+#
+# We have chosen to use the Coq base image as a base because it includes all
+# software required for building the Coq and OCaml parts of the artefact.
+# We will augment the image with the software require for the Haskell part.
+FROM coqorg/coq:8.9
+
+MAINTAINER Georgy Lukyanov
+
+RUN sudo apt-get update
+RUN sudo apt-get install -y wget m4
+RUN curl -sSL https://get.haskellstack.org/ | sh
+
+# Pull the OCaml sources from GitHub
+RUN wget -O selective-ocaml.zip https://github.com/snowleopard/selective-ocaml/archive/0.1.0.zip && \
+    unzip selective-ocaml.zip && rm selective-ocaml.zip && \
+    cd selective-ocaml-0.1.0 && \
+    opam install -y dune base stdio expect_test_helpers_kernel
+RUN cd selective-ocaml-0.1.0 && eval $(opam env) && make test
+RUN mv selective-ocaml-0.1.0 selective-ocaml
+
+# Pull the Coq sources from GitHub
+RUN wget -O selective-coq.zip https://github.com/tuura/selective-theory-coq/archive/v0.1.zip
+RUN unzip selective-coq.zip && rm selective-coq.zip && mv selective-theory-coq-0.1 selective-coq
+
+# Pull the Haskell sources from GitHub
+RUN wget -O selective.zip https://github.com/snowleopard/selective/archive/v0.2.zip
+RUN unzip selective.zip && rm selective.zip
+RUN cd selective-0.2 && stack build
+RUN mv selective-0.2 selective-haskell
+
+RUN exit
+```

--- a/paper/artefact/README.md
+++ b/paper/artefact/README.md
@@ -2,84 +2,65 @@
 
 This image contains a snapshot of the software packages related to the paper "Selective Applicative Functors" and all their dependencies.
 
-
 ## Running the image
 
 To run it interactively use the command: `docker run -it geo2a/selective-icfp19`.
 You will find yourself in the directory `/home/coq`.
 
-## Check Coq proofs
-
-To access th Coq development, execute the following command:
-
-```
-cd ~/selective-coq
-```
-
-To verify the Coq proofs of several Selective instances being lawful, execute:
-
-```
-make
-```
-
-TODO: what instance have been proven.
+The Haskell package contains an extensive set of QuickCheck properties, thus it is
+the most informative part of the artefact. We recommend taking a look at it first.
 
 ## Run Haskell tests
+
+Change into the Haskell directory:
 
 ```
 cd ~/selective-haskell
 ```
 
-## Run OCaml tests
+And run tests with `stack`:
+
+```
+stack test
+```
+
+Then you may take a look at the code in the top-level module
+`src/Control/Selective.hs`, which provides the `Selective` typeclass and auxiliary
+combinators.
+The free construction for rigid selective functors can be found in the
+`src/Control/Selective/Free/Rigid.hs'` file.
+
+## Check Coq proofs
+
+To access the Coq development, execute the following command:
+
+```
+cd ~/selective-coq
+```
+
+To typecheck all the Coq files in the development and verify the Coq proofs of
+several Selective instances being lawful, execute:
+
+```
+make
+```
+
+You may take a look at the simple instances in the files `src/Data/Over.v`,
+`src/Data/Under.v` and `src/Data/Validation.v`.
+
+## Take a look at the OCaml implementation
+
+Change into the OCaml directory:
 
 ```
 cd ~/selective-ocaml
 ```
 
-# Further activities
+The file `src/selective_intf.ml` contains the signature of the module definition
+`Selective.S` module, which provides the interface comprising all the Selective
+combinators.
 
-
-# Dockerfile
-
-Created using the following Dockerfile:
-
-```
-# Docker image prepared for ICFP'19 Artifact Evaluation.
-#
-# To build the image, run the following command in the directory containing
-# this Dockerfile: `docker build -t geo2a/selective-icfp19 .`
-#
-# To run a container interactively:
-# `docker run -it geo2a/selective-icfp19`
-#
-# We have chosen to use the Coq base image as a base because it includes all
-# software required for building the Coq and OCaml parts of the artefact.
-# We will augment the image with the software require for the Haskell part.
-FROM coqorg/coq:8.9
-
-MAINTAINER Georgy Lukyanov
-
-RUN sudo apt-get update
-RUN sudo apt-get install -y wget m4
-RUN curl -sSL https://get.haskellstack.org/ | sh
-
-# Pull the OCaml sources from GitHub
-RUN wget -O selective-ocaml.zip https://github.com/snowleopard/selective-ocaml/archive/0.1.0.zip && \
-    unzip selective-ocaml.zip && rm selective-ocaml.zip && \
-    cd selective-ocaml-0.1.0 && \
-    opam install -y dune base stdio expect_test_helpers_kernel
-RUN cd selective-ocaml-0.1.0 && eval $(opam env) && make test
-RUN mv selective-ocaml-0.1.0 selective-ocaml
-
-# Pull the Coq sources from GitHub
-RUN wget -O selective-coq.zip https://github.com/tuura/selective-theory-coq/archive/v0.1.zip
-RUN unzip selective-coq.zip && rm selective-coq.zip && mv selective-theory-coq-0.1 selective-coq
-
-# Pull the Haskell sources from GitHub
-RUN wget -O selective.zip https://github.com/snowleopard/selective/archive/v0.2.zip
-RUN unzip selective.zip && rm selective.zip
-RUN cd selective-0.2 && stack build
-RUN mv selective-0.2 selective-haskell
-
-RUN exit
-```
+You may take a look at the example S-expression parser, List instance and
+the Task Abstraction from
+["Build Systems à la Carte"](https://dl.acm.org/citation.cfm?id=3236774)
+([PDF](https://dl.acm.org/ft_gateway.cfm?id=3236774)) in the `examples/` directory.


### PR DESCRIPTION
Hi Andrey,

I have prepared the artefact and instructions on how to examine it. The Docker image which corresponds to the Dockerfile from this pull request is already on Docker Hub: https://cloud.docker.com/repository/docker/geo2a/selective-icfp19

The artefact contains the Haskell code and tests from this repo, our [Coq development](https://github.com/tuura/selective-theory-coq) and also the [OCaml code](https://github.com/snowleopard/selective-ocaml).

Please try to follow the instructions from the `README.md` and let me know if you want anything there changed.