### PR TITLE
Add functions returning Some in Rigid.Freer

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -40,7 +40,8 @@ library
                         Control.Selective.Rigid.Freer
     build-depends:      base         >= 4.7     && < 5,
                         containers   >= 0.5.5.1 && < 0.7,
-                        transformers >= 0.4.2.0 && < 0.6
+                        transformers >= 0.4.2.0 && < 0.6,
+                        some         >= 1.0.0.3 && < 1.1
     default-language:   Haskell2010
     other-extensions:   DeriveFunctor,
                         FlexibleInstances,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
 packages:
 - '.'
 resolver: lts-13.21
+extra-deps:
+- some-1.0.0.3


### PR DESCRIPTION
EDIT: `Selective.Free` could have same functions added, I'd add them there too, if this looks good otherwise.

I played with `selective` today, especially with various free formulations. This (= that you might want to diffentiate between `<*>` and `apS`) is IMHO insightful as demonstrated in subtly hidden example:

`Some` is nice when working with GADTs, allows to `show` things:

![Screenshot from 2019-10-24 22-35-43](https://user-images.githubusercontent.com/51087/67519109-d46a7600-f6ae-11e9-8265-5cd355c00b5b.png)

![Screenshot from 2019-10-24 22-36-05](https://user-images.githubusercontent.com/51087/67519205-05e34180-f6af-11e9-8245-3ff5cf06c426.png)
