### PR TITLE
Remove TypeApplications

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -49,8 +49,7 @@ library
                         GeneralizedNewtypeDeriving,
                         RankNTypes,
                         StandaloneDeriving,
-                        TupleSections,
-                        TypeApplications
+                        TupleSections
     GHC-options:        -Wall
                         -fno-warn-name-shadowing
                         -Wcompat


### PR DESCRIPTION
I'm attempting to add `selective`-support to `checkers` (https://github.com/conal/checkers/pull/51), but right now there is an unused dependency on TypeApplications. Removing it is a no-op, and allows selective to be compiled on older versions of GHC.