### PR TITLE
Eta-expand definitions to type check with simplified subsumption.

### DIFF
--- a/src/Control/Selective/Free.hs
+++ b/src/Control/Selective/Free.hs
@@ -43,7 +43,7 @@ instance Selective (Select f) where
 
 -- | Lift a functor into a free selective computation.
 liftSelect :: f a -> Select f a
-liftSelect x = Select ($x)
+liftSelect x = Select (\f -> f x)
 
 -- | Given a natural transformation from @f@ to @g@, this gives a canonical
 -- natural transformation from @Select f@ to @g@. Note that here we rely on the

--- a/src/Control/Selective/Multi.hs
+++ b/src/Control/Selective/Multi.hs
@@ -251,7 +251,7 @@ identity = id
 -- a tag, get the payload of the first product and then pass it as input to the
 -- second. This feels too trivial to be useful but is still somewhat cute.
 compose :: (u ~> v) -> (t ~> u) -> (t ~> v)
-compose = (.)
+compose f g = f . g
 
 -- | Update a generalised sum given a generalised product that takes care of all
 -- possible cases.


### PR DESCRIPTION
Due to the implementation of simplified subsumption (https://github.com/ghc-proposals/ghc-proposals/blob/wip/spj-deep-skol/proposals/0000-simplify-subsumption.md), these two functions no longer type check under GHC 9, and so this package fails to build.  The solution is simple: eta-expand their definitions.