### PR TITLE
Fix lower bound on base

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -35,7 +35,7 @@ library
                         Control.Selective.Multi,
                         Control.Selective.Rigid.Free,
                         Control.Selective.Rigid.Freer
-    build-depends:      base         >= 4.7     && < 5,
+    build-depends:      base         >= 4.9     && < 5,
                         containers   >= 0.5.5.1 && < 0.7,
                         transformers >= 0.4.2.0 && < 0.6
     default-language:   Haskell2010


### PR DESCRIPTION
GHC-7.10.3 and older fail to build selective:

    ghc: unrecognised flag: -Wcompat
    unrecognised flag: -Wincomplete-record-updates
    did you mean one of:
      -fwarn-incomplete-record-updates
    unrecognised flag: -Wincomplete-uni-patterns
    did you mean one of:
      -fwarn-incomplete-uni-patterns
    unrecognised flag: -Wredundant-constraints