### PR TITLE
Drop dependency on mtl

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -52,6 +52,8 @@ library
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wredundant-constraints
+    if impl(ghc >= 9.2)
+        ghc-options:    -Wno-operator-whitespace-ext-conflict
 
 test-suite test
     hs-source-dirs:     test, examples
@@ -81,3 +83,5 @@ test-suite test
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wredundant-constraints
+    if impl(ghc >= 9.2)
+        ghc-options:    -Wno-operator-whitespace-ext-conflict

--- a/selective.cabal
+++ b/selective.cabal
@@ -68,7 +68,6 @@ test-suite test
     main-is:            Main.hs
     build-depends:      base                   >= 4.7     && < 5,
                         containers             >= 0.5.5.1 && < 0.7,
-                        mtl                    >= 2.2.1   && < 2.3,
                         QuickCheck             >= 2.8     && < 2.15,
                         selective,
                         tasty                  >= 0.11,

--- a/test/Sketch.hs
+++ b/test/Sketch.hs
@@ -565,7 +565,7 @@ data Result a = Done a | Blocked BlockedRequests (Haxl a) deriving Functor
 newtype Haxl a = Haxl { runHaxl :: IO (Result a) } deriving Functor
 
 instance Applicative Haxl where
-    pure = return
+    pure = Haxl . return . Done
 
     Haxl iof <*> Haxl iox = Haxl $ do
         rf <- iof
@@ -586,7 +586,7 @@ instance Selective Haxl where
             (Blocked bx x  , Blocked bf f) -> Blocked (bx <> bf) (select x f) -- speculative
                                                                               -- execution
 instance Monad Haxl where
-    return = Haxl . return . Done
+    return = pure
 
     Haxl iox >>= f = Haxl $ do
         rx <- iox


### PR DESCRIPTION
See #44. There is really no need to depend on `mtl` since we need to modify the `MonadState` class anyway.