### PR TITLE
Bump base lower bound, add DerivingVia to other-extensions

### DIFF
--- a/selective.cabal
+++ b/selective.cabal
@@ -36,7 +36,7 @@ library
                         Control.Selective.Rigid.Free,
                         Control.Selective.Rigid.Freer,
                         Control.Selective.Trans.Except
-    build-depends:      base         >= 4.9     && < 5,
+    build-depends:      base         >= 4.12    && < 5,
                         containers   >= 0.5.5.1 && < 0.7,
                         transformers >= 0.4.2.0 && < 0.7
     default-language:   Haskell2010
@@ -46,7 +46,8 @@ library
                         GeneralizedNewtypeDeriving,
                         RankNTypes,
                         StandaloneDeriving,
-                        TupleSections
+                        TupleSections,
+                        DerivingVia
     ghc-options:        -Wall
                         -fno-warn-name-shadowing
                         -Wcompat


### PR DESCRIPTION
This makes the GHC-8.6 lower bound explicit.